### PR TITLE
add get_ce_analysis_status

### DIFF
--- a/sonarqube/community/ce.py
+++ b/sonarqube/community/ce.py
@@ -76,11 +76,12 @@ class SonarQubeCe(RestClient):
         """
 
     @GET(API_CE_ANALYSIS_STATUS_ENDPOINT)
-    def get_ce_analysis_status(self, component):
+    def get_ce_analysis_status(self, component, pullRequest):
         """
         Get last analysis status including warnings of a given component (usually a project).
 
         :param component: Component key
+        :param pullRequest: pull request id
         :return:
         """
 

--- a/sonarqube/community/ce.py
+++ b/sonarqube/community/ce.py
@@ -76,12 +76,13 @@ class SonarQubeCe(RestClient):
         """
 
     @GET(API_CE_ANALYSIS_STATUS_ENDPOINT)
-    def get_ce_analysis_status(self, component, pullRequest):
+    def get_ce_analysis_status(self, branch, component, pullRequest):
         """
         Get last analysis status including warnings of a given component (usually a project).
 
+        :param branch: Branch key
         :param component: Component key
-        :param pullRequest: pull request id
+        :param pullRequest: Pull request id
         :return:
         """
 

--- a/sonarqube/community/ce.py
+++ b/sonarqube/community/ce.py
@@ -75,7 +75,7 @@ class SonarQubeCe(RestClient):
         """
 
     @GET(API_CE_ANALYSIS_STATUS_ENDPOINT)
-    def get_ce_analysis_status(self, component)
+    def get_ce_analysis_status(self, component):
         """
         Get last analysis status including warnings of a given component (usually a project).
 

--- a/sonarqube/community/ce.py
+++ b/sonarqube/community/ce.py
@@ -5,6 +5,7 @@ from sonarqube.utils.rest_client import RestClient
 from sonarqube.utils.config import (
     API_CE_ACTIVITY_ENDPOINT,
     API_CE_ACTIVITY_STATUS_ENDPOINT,
+    API_CE_ANALYSIS_STATUS_ENDPOINT,
     API_CE_COMPONENT_ENDPOINT,
     API_CE_TASK_ENDPOINT,
 )

--- a/sonarqube/community/ce.py
+++ b/sonarqube/community/ce.py
@@ -74,6 +74,15 @@ class SonarQubeCe(RestClient):
         :return:
         """
 
+    @GET(API_CE_ANALYSIS_STATUS_ENDPOINT)
+    def get_ce_analysis_status(self, component)
+        """
+        Get last analysis status including warnings of a given component (usually a project).
+
+        :param component: Component key
+        :return:
+        """
+
     @GET(API_CE_COMPONENT_ENDPOINT)
     def get_component_queue_and_current_tasks(self, component):
         """

--- a/sonarqube/utils/config.py
+++ b/sonarqube/utils/config.py
@@ -53,6 +53,7 @@ API_PERMISSIONS_UPDATE_TEMPLATE_ENDPOINT = "/api/permissions/update_template"
 
 API_CE_ACTIVITY_ENDPOINT = "/api/ce/activity"
 API_CE_ACTIVITY_STATUS_ENDPOINT = "/api/ce/activity_status"
+API_CE_ANALYSIS_STATUS_ENDPOINT = "/api/ce/analysis_status"
 API_CE_COMPONENT_ENDPOINT = "/api/ce/component"
 API_CE_TASK_ENDPOINT = "/api/ce/task"
 


### PR DESCRIPTION
this will allow querying warnings for an analysis, It is part of the internal api and available since version 7.4

reference: https://github.com/SonarSource/sonarqube/blob/master/sonar-ws/src/main/java/org/sonarqube/ws/client/ce/CeService.java#L93